### PR TITLE
refactor

### DIFF
--- a/server/api/admin/categories_test.go
+++ b/server/api/admin/categories_test.go
@@ -10,11 +10,12 @@ import (
 	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
+	"testing"
+
 	"shin-monta-no-mori/server/internal/app"
 	db "shin-monta-no-mori/server/internal/db/sqlc"
 	model "shin-monta-no-mori/server/internal/domains/models"
 	"shin-monta-no-mori/server/pkg/util"
-	"testing"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -78,7 +79,7 @@ func TestListCategories(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			w := httptest.NewRecorder()
-			req, _ := http.NewRequest("GET", "/api/v1/admin/categories/list", nil)
+			req, _ := http.NewRequest(http.MethodGet, "/api/v1/admin/categories/list", nil)
 			req.Header.Set("Authorization", "Bearer "+accessToken)
 
 			ctx.Server.Router.ServeHTTP(w, req)
@@ -201,7 +202,7 @@ func TestGetCategory(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			w := httptest.NewRecorder()
-			req, _ := http.NewRequest("GET", "/api/v1/admin/categories/"+tt.arg.id, nil)
+			req, _ := http.NewRequest(http.MethodGet, "/api/v1/admin/categories/"+tt.arg.id, nil)
 			req.Header.Set("Authorization", "Bearer "+accessToken)
 
 			ctx.Server.Router.ServeHTTP(w, req)
@@ -349,7 +350,7 @@ func TestSearchCategories(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			w := httptest.NewRecorder()
-			req, _ := http.NewRequest("GET", "/api/v1/admin/categories/search?q="+tt.arg.q, nil)
+			req, _ := http.NewRequest(http.MethodGet, "/api/v1/admin/categories/search?q="+tt.arg.q, nil)
 			req.Header.Set("Authorization", "Bearer "+accessToken)
 
 			ctx.Server.Router.ServeHTTP(w, req)
@@ -467,7 +468,7 @@ func TestEditParentCategory(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			w := httptest.NewRecorder()
 			body, contentType := tt.prepare()
-			req, _ := http.NewRequest("PUT", "/api/v1/admin/categories/parent/"+tt.arg.ID, body)
+			req, _ := http.NewRequest(http.MethodPut, "/api/v1/admin/categories/parent/"+tt.arg.ID, body)
 			req.Header.Set("Content-Type", contentType)
 			req.Header.Set("Authorization", "Bearer "+accessToken)
 
@@ -586,7 +587,7 @@ func TestEditChildCategory(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			w := httptest.NewRecorder()
 			body, contentType := tt.prepare()
-			req, _ := http.NewRequest("PUT", "/api/v1/admin/categories/child/"+tt.arg.ID, body)
+			req, _ := http.NewRequest(http.MethodPut, "/api/v1/admin/categories/child/"+tt.arg.ID, body)
 			req.Header.Set("Content-Type", contentType)
 			req.Header.Set("Authorization", "Bearer "+accessToken)
 
@@ -612,6 +613,7 @@ func TestEditChildCategory(t *testing.T) {
 		})
 	}
 }
+
 func TestDeleteChildCategory(t *testing.T) {
 	config, err := util.LoadConfig(AppEnvPath)
 	if err != nil {
@@ -679,7 +681,7 @@ func TestDeleteChildCategory(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			w := httptest.NewRecorder()
-			req, _ := http.NewRequest("DELETE", "/api/v1/admin/categories/child/"+tt.arg.ID, nil)
+			req, _ := http.NewRequest(http.MethodDelete, "/api/v1/admin/categories/child/"+tt.arg.ID, nil)
 			req.Header.Set("Authorization", "Bearer "+accessToken)
 
 			ctx.Server.Router.ServeHTTP(w, req)
@@ -717,6 +719,7 @@ func compareParentCategoryObjects(t *testing.T, got db.ParentCategory, want db.P
 		t.Errorf("differs: (-got +want)\n%s", d)
 	}
 }
+
 func compareChildCategoryObjects(t *testing.T, got db.ChildCategory, want db.ChildCategory, ignoreFieldsMap map[string][]string) {
 	if d := cmp.Diff(got, want, cmpopts.IgnoreFields(got, ignoreFieldsMap["Other"]...)); len(d) != 0 {
 		t.Errorf("differs: (-got +want)\n%s", d)

--- a/server/api/admin/characters_test.go
+++ b/server/api/admin/characters_test.go
@@ -69,7 +69,7 @@ func TestListCharacters(t *testing.T) {
 			// 取得するイメージの数を1にする
 			ctx.Server.Config.CharacterFetchLimit = tt.arg.fetchLimit
 			w := httptest.NewRecorder()
-			req, _ := http.NewRequest("GET", "/api/v1/admin/characters/list", nil)
+			req, _ := http.NewRequest(http.MethodGet, "/api/v1/admin/characters/list", nil)
 			req.Header.Set("Authorization", "Bearer "+accessToken)
 
 			ctx.Server.Router.ServeHTTP(w, req)
@@ -189,7 +189,7 @@ func TestSearchCharacters(t *testing.T) {
 			// 取得するイメージの数を1にする
 			ctx.Server.Config.CharacterFetchLimit = tt.arg.fetchLimit
 			w := httptest.NewRecorder()
-			req, _ := http.NewRequest("GET", "/api/v1/admin/characters/search?p="+tt.arg.page+"&q="+tt.arg.query, nil)
+			req, _ := http.NewRequest(http.MethodGet, "/api/v1/admin/characters/search?p="+tt.arg.page+"&q="+tt.arg.query, nil)
 			req.Header.Set("Authorization", "Bearer "+accessToken)
 
 			ctx.Server.Router.ServeHTTP(w, req)
@@ -274,7 +274,7 @@ func TestGetCharacter(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			w := httptest.NewRecorder()
-			req, _ := http.NewRequest("GET", "/api/v1/admin/characters/"+tt.arg.id, nil)
+			req, _ := http.NewRequest(http.MethodGet, "/api/v1/admin/characters/"+tt.arg.id, nil)
 			req.Header.Set("Authorization", "Bearer "+accessToken)
 
 			ctx.Server.Router.ServeHTTP(w, req)
@@ -406,7 +406,7 @@ func TestEditCharacter(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			w := httptest.NewRecorder()
 			body, contentType := tt.prepare()
-			req, _ := http.NewRequest("PUT", "/api/v1/admin/characters/"+tt.arg.ID, body)
+			req, _ := http.NewRequest(http.MethodPut, "/api/v1/admin/characters/"+tt.arg.ID, body)
 			req.Header.Set("Content-Type", contentType)
 			req.Header.Set("Authorization", "Bearer "+accessToken)
 

--- a/server/api/admin/illustrations_test.go
+++ b/server/api/admin/illustrations_test.go
@@ -11,6 +11,8 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"testing"
+
 	"shin-monta-no-mori/server/api"
 	"shin-monta-no-mori/server/internal/app"
 	db "shin-monta-no-mori/server/internal/db/sqlc"
@@ -18,7 +20,6 @@ import (
 	"shin-monta-no-mori/server/pkg/lib/password"
 	"shin-monta-no-mori/server/pkg/token"
 	"shin-monta-no-mori/server/pkg/util"
-	"testing"
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/go-cmp/cmp"
@@ -176,7 +177,7 @@ func TestListIllustrations(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			// 取得するイメージの数を1にする
 			c.Server.Config.ImageFetchLimit = tt.arg.imageFetchLimit
-			req, _ := http.NewRequest("GET", "/api/v1/admin/illustrations/list?p="+tt.arg.page, nil)
+			req, _ := http.NewRequest(http.MethodGet, "/api/v1/admin/illustrations/list?p="+tt.arg.page, nil)
 			req.Header.Set("Authorization", "Bearer "+accessToken)
 
 			w := httptest.NewRecorder()
@@ -296,7 +297,7 @@ func TestGetIllustration(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			w := httptest.NewRecorder()
-			req, _ := http.NewRequest("GET", "/api/v1/admin/illustrations/"+tt.arg.id, nil)
+			req, _ := http.NewRequest(http.MethodGet, "/api/v1/admin/illustrations/"+tt.arg.id, nil)
 			req.Header.Set("Authorization", "Bearer "+accessToken)
 
 			c.Server.Router.ServeHTTP(w, req)
@@ -446,7 +447,7 @@ func TestSearchIllustrations(t *testing.T) {
 			// 取得するイメージの数を1にする
 			c.Server.Config.ImageFetchLimit = tt.arg.imageFetchLimit
 			w := httptest.NewRecorder()
-			req, _ := http.NewRequest("GET", "/api/v1/admin/illustrations/search?p="+tt.arg.p+"&q="+tt.arg.q, nil)
+			req, _ := http.NewRequest(http.MethodGet, "/api/v1/admin/illustrations/search?p="+tt.arg.p+"&q="+tt.arg.q, nil)
 			req.Header.Set("Authorization", "Bearer "+accessToken)
 
 			c.Server.Router.ServeHTTP(w, req)
@@ -807,7 +808,7 @@ func TestEditIllustration(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			body, contentType := tt.prepare()
-			req := httptest.NewRequest("PUT", "/api/v1/admin/illustrations/"+tt.arg, body)
+			req := httptest.NewRequest(http.MethodPut, "/api/v1/admin/illustrations/"+tt.arg, body)
 			req.Header.Set("Content-Type", contentType)
 			req.Header.Set("Authorization", "Bearer "+accessToken)
 

--- a/server/api/user/categories_test.go
+++ b/server/api/user/categories_test.go
@@ -73,7 +73,7 @@ func TestListCategories(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			w := httptest.NewRecorder()
-			req, _ := http.NewRequest("GET", "/api/v1/categories/list", nil)
+			req, _ := http.NewRequest(http.MethodGet, "/api/v1/categories/list", nil)
 
 			ctx.Server.Router.ServeHTTP(w, req)
 

--- a/server/api/user/characters_test.go
+++ b/server/api/user/characters_test.go
@@ -92,7 +92,7 @@ func TestListCharacters(t *testing.T) {
 			// 取得するイメージの数を1にする
 			ctx.Server.Config.CharacterFetchLimit = tt.arg.fetchLimit
 			w := httptest.NewRecorder()
-			req, _ := http.NewRequest("GET", "/api/v1/characters/list?p="+tt.arg.page, nil)
+			req, _ := http.NewRequest(http.MethodGet, "/api/v1/characters/list?p="+tt.arg.page, nil)
 
 			ctx.Server.Router.ServeHTTP(w, req)
 

--- a/server/api/user/illustrations_test.go
+++ b/server/api/user/illustrations_test.go
@@ -170,7 +170,7 @@ func TestListIllustrations(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			// 取得するイメージの数を1にする
 			c.Server.Config.ImageFetchLimit = tt.arg.imageFetchLimit
-			req, _ := http.NewRequest("GET", "/api/v1/illustrations/list?p="+tt.arg.page, nil)
+			req, _ := http.NewRequest(http.MethodGet, "/api/v1/illustrations/list?p="+tt.arg.page, nil)
 
 			w := httptest.NewRecorder()
 			c.Server.Router.ServeHTTP(w, req)
@@ -284,7 +284,7 @@ func TestGetIllustration(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			w := httptest.NewRecorder()
-			req, _ := http.NewRequest("GET", "/api/v1/illustrations/"+tt.arg.id, nil)
+			req, _ := http.NewRequest(http.MethodGet, "/api/v1/illustrations/"+tt.arg.id, nil)
 
 			c.Server.Router.ServeHTTP(w, req)
 
@@ -430,7 +430,7 @@ func TestSearchIllustrations(t *testing.T) {
 			// 取得するイメージの数を1にする
 			c.Server.Config.ImageFetchLimit = tt.arg.imageFetchLimit
 			w := httptest.NewRecorder()
-			req, _ := http.NewRequest("GET", "/api/v1/illustrations/search?p="+tt.arg.p+"&q="+tt.arg.q, nil)
+			req, _ := http.NewRequest(http.MethodGet, "/api/v1/illustrations/search?p="+tt.arg.p+"&q="+tt.arg.q, nil)
 
 			c.Server.Router.ServeHTTP(w, req)
 
@@ -567,7 +567,7 @@ func TestListIllustrationsByParentCategoryID(t *testing.T) {
 			// 取得するイメージの数を1にする
 			c.Server.Config.ImageFetchLimit = tt.arg.imageFetchLimit
 			w := httptest.NewRecorder()
-			req, _ := http.NewRequest("GET", "/api/v1/illustrations/category/parent/"+tt.arg.id+"?p="+tt.arg.p, nil)
+			req, _ := http.NewRequest(http.MethodGet, "/api/v1/illustrations/category/parent/"+tt.arg.id+"?p="+tt.arg.p, nil)
 
 			c.Server.Router.ServeHTTP(w, req)
 
@@ -700,7 +700,7 @@ func TestListIllustrationsByCharacterID(t *testing.T) {
 			// 取得するイメージの数を1にする
 			c.Server.Config.ImageFetchLimit = tt.arg.imageFetchLimit
 			w := httptest.NewRecorder()
-			req, _ := http.NewRequest("GET", "/api/v1/illustrations/character/"+tt.arg.id+"?p="+tt.arg.p, nil)
+			req, _ := http.NewRequest(http.MethodGet, "/api/v1/illustrations/character/"+tt.arg.id+"?p="+tt.arg.p, nil)
 
 			c.Server.Router.ServeHTTP(w, req)
 
@@ -836,7 +836,7 @@ func TestListIllustrationsByChildCategoryID(t *testing.T) {
 			// 取得するイメージの数を1にする
 			c.Server.Config.ImageFetchLimit = tt.arg.imageFetchLimit
 			w := httptest.NewRecorder()
-			req, _ := http.NewRequest("GET", "/api/v1/illustrations/category/child/"+tt.arg.id+"?p="+tt.arg.p, nil)
+			req, _ := http.NewRequest(http.MethodGet, "/api/v1/illustrations/category/child/"+tt.arg.id+"?p="+tt.arg.p, nil)
 
 			c.Server.Router.ServeHTTP(w, req)
 

--- a/server/internal/app/server.go
+++ b/server/internal/app/server.go
@@ -2,6 +2,8 @@ package app
 
 import (
 	"fmt"
+	"net/http"
+
 	db "shin-monta-no-mori/server/internal/db/sqlc"
 	"shin-monta-no-mori/server/pkg/token"
 	"shin-monta-no-mori/server/pkg/util"
@@ -41,7 +43,7 @@ func CORSMiddleware(config util.Config) gin.HandlerFunc {
 		c.Writer.Header().Set("Access-Control-Expose-Headers", "Content-Length")
 		c.Writer.Header().Set("Access-Control-Allow-Credentials", "true")
 
-		if c.Request.Method == "OPTIONS" {
+		if c.Request.Method == http.MethodOptions {
 			c.AbortWithStatus(204)
 			return
 		}

--- a/server/internal/domains/service/illustration.go
+++ b/server/internal/domains/service/illustration.go
@@ -2,14 +2,16 @@ package service
 
 import (
 	"database/sql"
+	"errors"
 	"fmt"
 	"net/http"
 	"path/filepath"
+	"strings"
+
 	"shin-monta-no-mori/server/internal/app"
 	db "shin-monta-no-mori/server/internal/db/sqlc"
 	model "shin-monta-no-mori/server/internal/domains/models"
 	"shin-monta-no-mori/server/pkg/util"
-	"strings"
 
 	"github.com/gin-gonic/gin"
 )
@@ -108,7 +110,7 @@ func UploadImageSrc(c *gin.Context, config *util.Config, formKey string, filenam
 
 	ext := strings.ToLower(filepath.Ext(f.Filename))
 	if ext != ".png" {
-		return "", fmt.Errorf("please upload only png extension image")
+		return "", errors.New("please upload only png extension image")
 	}
 
 	storageService := &GCSStorageService{

--- a/server/pkg/util/random.go
+++ b/server/pkg/util/random.go
@@ -3,14 +3,9 @@ package util
 import (
 	"math/rand"
 	"strings"
-	"time"
 )
 
 const alphabet = "abcdefghijklmnopqrstuvwxyz"
-
-func init() {
-	rand.Seed(time.Now().UnixNano())
-}
 
 // RandomInt generates a random integer between min and max
 func RandomInt(min, max int64) int64 {


### PR DESCRIPTION
## 変更内容
- http.Method使用
- rand.Seed (go 1.20以上はrand.Seed呼び出しは不要になった)
- fmt.Errorf -> errors.New