### PR TITLE
画像リサイズ機能の実装

### DIFF
--- a/client/src/styles/globals.css
+++ b/client/src/styles/globals.css
@@ -38,3 +38,31 @@
     background-size: 70px 70px;
   }
 }
+
+.resize-bar {
+  input[type="range"] {
+    -webkit-appearance: none; /* スライダーのデフォルトスタイルを無効化 */
+    width: 100%;
+    height: 6px;
+    border-radius: 5px;
+    background: #e5e7eb; /* トラックの背景色 */
+  }
+
+  input[type="range"]::-webkit-slider-thumb {
+    -webkit-appearance: none;
+    appearance: none;
+    width: 16px;
+    height: 16px;
+    background: #17a34a; /* つまみの色 */
+    cursor: pointer;
+    border-radius: 50%;
+  }
+
+  input[type="range"]::-moz-range-thumb {
+    width: 16px;
+    height: 16px;
+    background: #17a34a; /* つまみの色 */
+    cursor: pointer;
+    border-radius: 50%;
+  }
+}


### PR DESCRIPTION
# 目的
画像サイズを自由に調整できるようにし、ユーザー体験を向上させる

# どんな実装
画像の下にサイズ調整バーを設置し、バーを触ることで、自由に画像サイズを調整することができる。

![スクリーンショット 2024-09-11 22 42 08](https://github.com/user-attachments/assets/3f7c7cb2-140c-4f3b-b8d1-fe98655b5969)

上記のバーを50%にしたら、元画像から50%サイズが小さい画像が生成される。
このサイズ調整した状態で画像をダウンロード or コピーすると、50%サイズ調整された画像をダウンロード or コピーすることができる。